### PR TITLE
Removes service name from circle.yml coveralls command

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,4 +4,4 @@ test:
   override:
     - go test -v -cover -race -coverprofile=/home/ubuntu/coverage.out
   post:
-    - goveralls -coverprofile=/home/ubuntu/coverage.out -service=circle-ci -repotoken=$COVERALLS_TOKEN
+    - goveralls -coverprofile=/home/ubuntu/coverage.out -repotoken=$COVERALLS_TOKEN

--- a/circle.yml
+++ b/circle.yml
@@ -4,4 +4,4 @@ test:
   override:
     - go test -v -cover -race -coverprofile=/home/ubuntu/coverage.out
   post:
-    - goveralls -coverprofile=/home/ubuntu/coverage.out -repotoken=$COVERALLS_TOKEN
+    - goveralls -coverprofile=/home/ubuntu/coverage.out -service=circle-ci


### PR DESCRIPTION
Coveralls is complaining about missing job_id the documentation says you can use either service_name and job_id or a token, will leave just the token to try to fix that.