### PR TITLE
Initial support for multiple bot instances

### DIFF
--- a/cmd_test.go
+++ b/cmd_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -22,7 +23,7 @@ func responseHandler(target string, message string, sender *User) {
 func TestMessageReceived(t *testing.T) {
 	Convey("Given a new message in the channel", t, func() {
 		commands = make(map[string]*customCommand)
-		New(&Handlers{
+		b := New(&Handlers{
 			Response: responseHandler,
 		})
 
@@ -34,7 +35,7 @@ func TestMessageReceived(t *testing.T) {
 
 		Convey("When the command is not registered", func() {
 			Convey("It should not post to the channel", func() {
-				MessageReceived("#go-bot", "!not_a_cmd", &User{})
+				b.MessageReceived("#go-bot", "!not_a_cmd", &User{})
 
 				So(replies, ShouldBeEmpty)
 			})
@@ -48,7 +49,7 @@ func TestMessageReceived(t *testing.T) {
 						return "", cmdError
 					})
 
-				MessageReceived("#go-bot", "!cmd", &User{Nick: "user"})
+				b.MessageReceived("#go-bot", "!cmd", &User{Nick: "user"})
 
 				So(channel, ShouldEqual, "#go-bot")
 				So(replies, ShouldResemble,
@@ -69,7 +70,7 @@ func TestMessageReceived(t *testing.T) {
 				})
 
 			Convey("If it is called in the channel, reply on the channel", func() {
-				MessageReceived("#go-bot", "!cmd", &User{Nick: "user"})
+				b.MessageReceived("#go-bot", "!cmd", &User{Nick: "user"})
 
 				So(channel, ShouldEqual, "#go-bot")
 				So(replies, ShouldResemble, []string{expectedMsg})
@@ -77,13 +78,13 @@ func TestMessageReceived(t *testing.T) {
 
 			Convey("If it is a private message, reply to the user", func() {
 				user = &User{Nick: "go-bot"}
-				MessageReceived("go-bot", "!cmd", &User{Nick: "sender-nick"})
+				b.MessageReceived("go-bot", "!cmd", &User{Nick: "sender-nick"})
 				So(user.Nick, ShouldEqual, "sender-nick")
 			})
 
 			Convey("When the command is help", func() {
 				Convey("Display the available commands in the channel", func() {
-					MessageReceived("#go-bot", "!help", &User{Nick: "user"})
+					b.MessageReceived("#go-bot", "!help", &User{Nick: "user"})
 
 					So(channel, ShouldEqual, "#go-bot")
 					So(replies, ShouldResemble, []string{
@@ -93,7 +94,7 @@ func TestMessageReceived(t *testing.T) {
 				})
 
 				Convey("If the command exists send a message to the channel", func() {
-					MessageReceived("#go-bot", "!help cmd", &User{Nick: "user"})
+					b.MessageReceived("#go-bot", "!help cmd", &User{Nick: "user"})
 
 					So(channel, ShouldEqual, "#go-bot")
 					So(replies, ShouldResemble, []string{
@@ -103,7 +104,7 @@ func TestMessageReceived(t *testing.T) {
 				})
 
 				Convey("If the command does not exists, display the generic help", func() {
-					MessageReceived("#go-bot", "!help not_a_command", &User{Nick: "user"})
+					b.MessageReceived("#go-bot", "!help not_a_command", &User{Nick: "user"})
 
 					So(channel, ShouldEqual, "#go-bot")
 					So(replies, ShouldResemble, []string{
@@ -123,7 +124,7 @@ func TestMessageReceived(t *testing.T) {
 							Message: "message"}, nil
 					})
 
-				MessageReceived("#go-bot", "!cmd", &User{Nick: "user"})
+				b.MessageReceived("#go-bot", "!cmd", &User{Nick: "user"})
 
 				So(channel, ShouldEqual, "#channel")
 				So(replies, ShouldResemble, []string{"message"})
@@ -136,7 +137,7 @@ func TestMessageReceived(t *testing.T) {
 							Message: "message"}, nil
 					})
 
-				MessageReceived("#go-bot", "!cmd", &User{Nick: "user"})
+				b.MessageReceived("#go-bot", "!cmd", &User{Nick: "user"})
 
 				So(channel, ShouldEqual, "#go-bot")
 				So(replies, ShouldResemble, []string{"message"})
@@ -161,7 +162,7 @@ func TestMessageReceived(t *testing.T) {
 			RegisterPassiveCommand("errored", errored)
 
 			Convey("If it is called in the channel, reply on the channel", func() {
-				MessageReceived("#go-bot", "test", &User{Nick: "user"})
+				b.MessageReceived("#go-bot", "test", &User{Nick: "user"})
 
 				So(channel, ShouldEqual, "#go-bot")
 				So(len(replies), ShouldEqual, 2)
@@ -171,7 +172,7 @@ func TestMessageReceived(t *testing.T) {
 
 			Convey("If it is a private message, reply to the user", func() {
 				user = &User{Nick: "go-bot"}
-				MessageReceived("go-bot", "test", &User{Nick: "sender-nick"})
+				b.MessageReceived("go-bot", "test", &User{Nick: "sender-nick"})
 
 				So(user.Nick, ShouldEqual, "sender-nick")
 				So(len(replies), ShouldEqual, 2)

--- a/help.go
+++ b/help.go
@@ -13,34 +13,34 @@ const (
 	helpCommand       = "help"
 )
 
-func help(c *Cmd) {
+func (b *Bot) help(c *Cmd) {
 	cmd := parse(CmdPrefix+c.RawArgs, c.Channel, c.User)
 	if cmd == nil {
-		showAvailabeCommands(c.Channel, c.User)
+		b.showAvailabeCommands(c.Channel, c.User)
 		return
 	}
 
 	command := commands[cmd.Command]
 	if command == nil {
-		showAvailabeCommands(c.Channel, c.User)
+		b.showAvailabeCommands(c.Channel, c.User)
 		return
 	}
 
-	showHelp(cmd, command)
+	b.showHelp(cmd, command)
 }
 
-func showHelp(c *Cmd, help *customCommand) {
+func (b *Bot) showHelp(c *Cmd, help *customCommand) {
 	if help.Description != "" {
-		handlers.Response(c.Channel, fmt.Sprintf(helpDescripton, help.Description), c.User)
+		b.handlers.Response(c.Channel, fmt.Sprintf(helpDescripton, help.Description), c.User)
 	}
-	handlers.Response(c.Channel, fmt.Sprintf(helpUsage, CmdPrefix, c.Command, help.ExampleArgs), c.User)
+	b.handlers.Response(c.Channel, fmt.Sprintf(helpUsage, CmdPrefix, c.Command, help.ExampleArgs), c.User)
 }
 
-func showAvailabeCommands(channel string, sender *User) {
+func (b *Bot) showAvailabeCommands(channel string, sender *User) {
 	var cmds []string
 	for k := range commands {
 		cmds = append(cmds, k)
 	}
-	handlers.Response(channel, fmt.Sprintf(helpAboutCommand, CmdPrefix), sender)
-	handlers.Response(channel, fmt.Sprintf(availableCommands, strings.Join(cmds, ", ")), sender)
+	b.handlers.Response(channel, fmt.Sprintf(helpAboutCommand, CmdPrefix), sender)
+	b.handlers.Response(channel, fmt.Sprintf(availableCommands, strings.Join(cmds, ", ")), sender)
 }

--- a/irc/irc.go
+++ b/irc/irc.go
@@ -24,6 +24,7 @@ type Config struct {
 var (
 	ircConn *ircevent.Connection
 	config  *Config
+	b       *bot.Bot
 )
 
 func responseHandler(target string, message string, sender *bot.User) {
@@ -35,7 +36,7 @@ func responseHandler(target string, message string, sender *bot.User) {
 }
 
 func onPRIVMSG(e *ircevent.Event) {
-	bot.MessageReceived(e.Arguments[0], e.Message(), &bot.User{Nick: e.Nick})
+	b.MessageReceived(e.Arguments[0], e.Message(), &bot.User{Nick: e.Nick})
 }
 
 func getServerName(server string) string {
@@ -65,7 +66,7 @@ func Run(c *Config) {
 	}
 	ircConn.VerboseCallbackHandler = c.Debug
 
-	bot.New(&bot.Handlers{
+	b = bot.New(&bot.Handlers{
 		Response: responseHandler,
 	})
 

--- a/slack/slack.go
+++ b/slack/slack.go
@@ -31,7 +31,7 @@ func Run(token string) {
 	api = slack.New(token)
 	rtm = api.NewRTM()
 
-	bot.New(&bot.Handlers{
+	b := bot.New(&bot.Handlers{
 		Response: responseHandler,
 	})
 
@@ -43,7 +43,7 @@ Loop:
 		case msg := <-rtm.IncomingEvents:
 			switch ev := msg.Data.(type) {
 			case *slack.MessageEvent:
-				bot.MessageReceived(ev.Channel, ev.Text, extractUser(ev.User))
+				b.MessageReceived(ev.Channel, ev.Text, extractUser(ev.User))
 
 			case *slack.RTMError:
 				fmt.Printf("Error: %s\n", ev.Error())

--- a/telegram/telegram.go
+++ b/telegram/telegram.go
@@ -44,13 +44,13 @@ func Run(token string, debug bool) {
 		log.Fatal(err)
 	}
 
-	bot.New(&bot.Handlers{
+	b := bot.New(&bot.Handlers{
 		Response: responseHandler,
 	})
 
 	for update := range updates {
 		target := strconv.Itoa(update.Message.Chat.ID)
 		sender := strconv.Itoa(update.Message.From.ID)
-		bot.MessageReceived(target, update.Message.Text, &bot.User{Nick: sender})
+		b.MessageReceived(target, update.Message.Text, &bot.User{Nick: sender})
 	}
 }


### PR DESCRIPTION
This allows to run multiple bot instances on the same app.

Right now it is not possible to select which plugins will be available
in each instance, but I'm planning to implement that soon. The idea so
far is to keep the plugins registrations on the init() func but make
possible to disable a command in an instance.

Also I don't think that the PeriodicCommands must be registered
globally, as at least for my needs I have different channels and needs
for each instance, so it would be best to register this kind of commands
in a per instance basis.