### PR TITLE
Updated slack's extractUser to send return the nickname instead of the ID

### DIFF
--- a/slack/slack.go
+++ b/slack/slack.go
@@ -23,7 +23,7 @@ func extractUser(userID string) *bot.User {
 		fmt.Printf("Error retrieving slack user: %s\n", err)
 		return &bot.User{Nick: userID}
 	}
-	return &bot.User{Nick: userID, RealName: slackUser.Profile.RealName}
+	return &bot.User{Nick: slackUser.Name, RealName: slackUser.Profile.RealName}
 }
 
 // Run connects to slack RTM API using the provided token


### PR DESCRIPTION
Found a small issue with the return of ``extractUser``; instead of returning the nick name it was returning the ID. This PR fixes that.