### PR TITLE
Allows disabling commands and disables url plugin on Slack and Telegram

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -17,8 +17,9 @@ const (
 
 // Bot handles the bot instance
 type Bot struct {
-	handlers *Handlers
-	cron     *cron.Cron
+	handlers     *Handlers
+	cron         *cron.Cron
+	disabledCmds []string
 }
 
 // ResponseHandler must be implemented by the protocol to handle the bot responses

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -20,6 +20,39 @@ func responseHandler(target string, message string, sender *User) {
 	replies = append(replies, message)
 }
 
+func TestDisableCommands(t *testing.T) {
+	Convey("Allow disabling commands", t, func() {
+		commands = make(map[string]*customCommand)
+		b := New(&Handlers{
+			Response: responseHandler,
+		})
+
+		RegisterCommand("cmd", "", "",
+			func(c *Cmd) (string, error) {
+				return "active", nil
+			})
+
+		RegisterPassiveCommand("passive",
+			func(cmd *PassiveCmd) (string, error) {
+				return "passive", nil
+			})
+
+		Convey("When the disabled command is active", func() {
+			b.Disable([]string{"cmd"})
+			b.MessageReceived("#go-bot", "!cmd", &User{Nick: "user"})
+
+			So(replies, ShouldBeEmpty)
+		})
+
+		Convey("When the disabled command is passive", func() {
+			b.Disable([]string{"passive"})
+			b.MessageReceived("#go-bot", "regular message", &User{Nick: "user"})
+
+			So(replies, ShouldBeEmpty)
+		})
+	})
+}
+
 func TestMessageReceived(t *testing.T) {
 	Convey("Given a new message in the channel", t, func() {
 		commands = make(map[string]*customCommand)

--- a/slack/slack.go
+++ b/slack/slack.go
@@ -35,6 +35,7 @@ func Run(token string) {
 	b := bot.New(&bot.Handlers{
 		Response: responseHandler,
 	})
+	b.Disable([]string{"url"})
 
 	go rtm.ManageConnection()
 

--- a/telegram/telegram.go
+++ b/telegram/telegram.go
@@ -48,6 +48,7 @@ func Run(token string, debug bool) {
 	b := bot.New(&bot.Handlers{
 		Response: responseHandler,
 	})
+	b.Disable([]string{"url"})
 
 	for update := range updates {
 		target := strconv.Itoa(update.Message.Chat.ID)


### PR DESCRIPTION
Slack and Telegram already have url handlers, so it makes no sense to show the url title twice.