### PR TITLE
Periodic commands with channel argument

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -47,7 +47,6 @@ func (b *Bot) startPeriodicCommands() {
 				message, err := config.CmdFunc(channel)
 				if err != nil {
 					log.Print("Periodic command failed ", err)
-					return
 				} else if message != "" {
 					b.handlers.Response(channel, message, nil)
 				}

--- a/bot.go
+++ b/bot.go
@@ -43,13 +43,12 @@ func New(h *Handlers) *Bot {
 func (b *Bot) startPeriodicCommands() {
 	for _, config := range periodicCommands {
 		b.cron.AddFunc(config.CronSpec, func() {
-			message, err := config.CmdFunc()
-			if err != nil {
-				log.Print("Periodic command failed ", err)
-				return
-			}
-			if message != "" {
-				for _, channel := range config.Channels {
+			for _, channel := range config.Channels {
+				message, err := config.CmdFunc(channel)
+				if err != nil {
+					log.Print("Periodic command failed ", err)
+					return
+				} else if message != "" {
 					b.handlers.Response(channel, message, nil)
 				}
 			}

--- a/cmd.go
+++ b/cmd.go
@@ -26,9 +26,9 @@ type PassiveCmd struct {
 
 // PeriodicConfig holds a cron specification for periodically notifying the configured channels
 type PeriodicConfig struct {
-	CronSpec string                                 // CronSpec that schedules some function
-	Channels []string                               // A list of channels to notify
-	CmdFunc  func(channel string) (string, error)   // func to be executed at the period specified on CronSpec
+	CronSpec string					// CronSpec that schedules some function
+	Channels []string				// A list of channels to notify
+	CmdFunc  func(channel string) (string, error)	// func to be executed at the period specified on CronSpec
 }
 
 // User holds user id (nick) and real name

--- a/cmd.go
+++ b/cmd.go
@@ -26,9 +26,9 @@ type PassiveCmd struct {
 
 // PeriodicConfig holds a cron specification for periodically notifying the configured channels
 type PeriodicConfig struct {
-	CronSpec string                 // CronSpec that schedules some function
-	Channels []string               // A list of channels to notify
-	CmdFunc  func() (string, error) // func to be executed at the period specified on CronSpec
+	CronSpec string                                 // CronSpec that schedules some function
+	Channels []string                               // A list of channels to notify
+	CmdFunc  func(channel string) (string, error)   // func to be executed at the period specified on CronSpec
 }
 
 // User holds user id (nick) and real name

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -33,7 +33,7 @@ func TestPeriodicCommands(t *testing.T) {
 			PeriodicConfig{
 				CronSpec: "0 0 08 * * mon-fri",
 				Channels: []string{"#channel"},
-				CmdFunc:  func(channel string) (string, error) { return "ok", nil },
+				CmdFunc:  func(channel string) (string, error) { return "ok " + channel, nil },
 			})
 
 		b := New(&Handlers{Response: responseHandler})
@@ -45,7 +45,7 @@ func TestPeriodicCommands(t *testing.T) {
 		entries[0].Job.Run()
 
 		So(replies, ShouldHaveLength, 1)
-		So(replies[0], ShouldEqual, "ok")
+		So(replies[0], ShouldEqual, "ok #channel")
 	})
 }
 

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -33,7 +33,7 @@ func TestPeriodicCommands(t *testing.T) {
 			PeriodicConfig{
 				CronSpec: "0 0 08 * * mon-fri",
 				Channels: []string{"#channel"},
-				CmdFunc:  func() (string, error) { return "ok", nil },
+				CmdFunc:  func(channel string) (string, error) { return "ok", nil },
 			})
 
 		b := New(&Handlers{Response: responseHandler})


### PR DESCRIPTION
This is something I should've implemented in the initial PR. :-) My usecase for this is a plugin that does *something* per configured user and messages them with the result. It's too bad that this breaks the initial API, but I don't see a way around it, except having multiple functions in a periodic config which seems kind of messy.

I've also fixed the related good-morning-plugin in the plugin repo. If this gets accepted I'll open a PR there as well. :-)