### PR TITLE
Uses PostMessage instead of SendMessage

### DIFF
--- a/slack/slack.go
+++ b/slack/slack.go
@@ -13,8 +13,12 @@ var (
 	api *slack.Client
 )
 
+const (
+	params = slack.PostMessageParameters{AsUser: true}
+)
+
 func responseHandler(target string, message string, sender *bot.User) {
-	rtm.SendMessage(rtm.NewOutgoingMessage(message, target))
+	api.PostMessage(target, message, params)
 }
 
 // Extracts user information from slack API


### PR DESCRIPTION
PostMessage is able to post to users by nick (@nick) and channels by name (#channel). It does also seem to handle channel ids and direct message-ids, so this should keep existing functionality intact.