### PR TITLE
Ensure Chat IDs are valid for Telegram supergroups.

### DIFF
--- a/telegram/telegram.go
+++ b/telegram/telegram.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"strconv"
 
-	"github.com/Syfaro/telegram-bot-api"
 	"github.com/go-chat-bot/bot"
+	"gopkg.in/telegram-bot-api.v3"
 )
 
 var (
@@ -14,7 +14,7 @@ var (
 )
 
 func responseHandler(target string, message string, sender *bot.User) {
-	id, err := strconv.Atoi(target)
+	id, err := strconv.ParseInt(target, 10, 64)
 	if err != nil {
 		log.Println(err)
 		return
@@ -51,7 +51,7 @@ func Run(token string, debug bool) {
 	b.Disable([]string{"url"})
 
 	for update := range updates {
-		target := strconv.Itoa(update.Message.Chat.ID)
+		target := strconv.FormatInt(update.Message.Chat.ID, 10)
 		sender := strconv.Itoa(update.Message.From.ID)
 		b.MessageReceived(target, update.Message.Text, &bot.User{Nick: sender})
 	}


### PR DESCRIPTION
Telegram's supergroups have very large IDs, compared to the size of group IDs previously. An update in go-telegram-bot-api allows for ensuring that IDs do not overflow an int. This pull request updates the Telegram protocol to utilize these changes.

Also changed is the import for go-telegram-bot-api. By using a gopkg.in versioned import, even if there are breaking changes on go-telegram-bot-api/master, it will still build successfully. 