### PR TITLE
Fix Slack protocol having a build error

### DIFF
--- a/slack/slack.go
+++ b/slack/slack.go
@@ -11,9 +11,7 @@ import (
 var (
 	rtm *slack.RTM
 	api *slack.Client
-)
 
-const (
 	params = slack.PostMessageParameters{AsUser: true}
 )
 


### PR DESCRIPTION
Upon attempting to build the Slack protocol, I got this error.

```# github.com/go-chat-bot/bot/slack
slack/slack.go:17: const initializer slack.PostMessageParameters literal is not a constant```

This pull request resolves that build error by changing `params` to a var instead of const. 