### PR TITLE
Fix issue with passive trigger plugins

### DIFF
--- a/irc/irc.go
+++ b/irc/irc.go
@@ -34,8 +34,10 @@ func responseHandler(target string, message string, sender *bot.User) {
 		channel = sender.Nick
 	}
 
-	for _, line := range strings.Split(message, "\n") {
-		ircConn.Privmsg(channel, line)
+	if message != "" {
+		for _, line := range strings.Split(message, "\n") {
+			ircConn.Privmsg(channel, line)
+		}
 	}
 }
 


### PR DESCRIPTION
When using plugins with passive triggers, returning an empty string would result in the bot sending a newline with no content to the IRC server.  This change prevents that.