### PR TITLE
parse slack text message with url to raw

### DIFF
--- a/slack/slack.go
+++ b/slack/slack.go
@@ -3,6 +3,8 @@ package slack
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
 
 	"github.com/go-chat-bot/bot"
 	"github.com/nlopes/slack"
@@ -55,6 +57,17 @@ func extractUser(event *slack.MessageEvent) *bot.User {
 		IsBot:    isBot}
 }
 
+func parse(msgtxt string) string {
+	regx := regexp.MustCompile("<[^<>]+>")
+	matches := regx.FindAllString(msgtxt, -1)
+	for _, match := range matches {
+		clean := strings.Split(match, "|")[1]
+		clean = clean[:len(clean)-1]
+		msgtxt = strings.Replace(msgtxt, match, clean, -1)
+	}
+	return msgtxt
+}
+
 func extractText(event *slack.MessageEvent) *bot.Message {
 	msg := &bot.Message{}
 	if len(event.Text) != 0 {
@@ -68,6 +81,7 @@ func extractText(event *slack.MessageEvent) *bot.Message {
 			msg.Text = attachments[0].Fallback
 		}
 	}
+	msg.Text = parse(msg.Text)
 	return msg
 }
 

--- a/slack/slack.go
+++ b/slack/slack.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/go-chat-bot/bot"
+	"github.com/dwdraju/bot"
 	"github.com/nlopes/slack"
 )
 


### PR DESCRIPTION
Parse slack posted url that converts: `<http://gcr.io|gcr.io>` into `gcr.io`.