### PR TITLE
Make it possible to use the bot to send notifications

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -91,6 +91,10 @@ func (b *Bot) MessageReceived(channel *ChannelData, message *Message, sender *Us
 	}
 }
 
+func (b *Bot) SendUnsolicitedMessage(target string, message string, sender *User) {
+	b.handlers.Response(target, message, sender)
+}
+
 func init() {
 	rand.Seed(time.Now().UnixNano())
 }

--- a/bot.go
+++ b/bot.go
@@ -49,7 +49,7 @@ func (b *Bot) startPeriodicCommands() {
 					if err != nil {
 						log.Print("Periodic command failed ", err)
 					} else if message != "" {
-						b.handlers.Response(channel, message, nil)
+						b.SendMessage(channel, message, nil)
 					}
 				}
 			})
@@ -64,7 +64,7 @@ func (b *Bot) startPeriodicCommands() {
 func (b *Bot) MessageReceived(channel *ChannelData, message *Message, sender *User) {
 	command, err := parse(message.Text, channel, sender)
 	if err != nil {
-		b.handlers.Response(channel.Channel, err.Error(), sender)
+		b.SendMessage(channel.Channel, err.Error(), sender)
 		return
 	}
 
@@ -91,7 +91,8 @@ func (b *Bot) MessageReceived(channel *ChannelData, message *Message, sender *Us
 	}
 }
 
-func (b *Bot) SendUnsolicitedMessage(target string, message string, sender *User) {
+// Sends a message to a target recipient, optionally from a particular sender.
+func (b *Bot) SendMessage(target string, message string, sender *User) {
 	b.handlers.Response(target, message, sender)
 }
 

--- a/cmd.go
+++ b/cmd.go
@@ -192,7 +192,7 @@ func (b *Bot) executePassiveCommands(cmd *PassiveCmd) {
 				log.Println(err)
 			} else {
 				mutex.Lock()
-				b.handlers.Response(cmd.Channel, result, cmd.User)
+				b.SendMessage(cmd.Channel, result, cmd.User)
 				mutex.Unlock()
 			}
 		}()
@@ -222,7 +222,7 @@ func (b *Bot) handleCmd(c *Cmd) {
 		message, err := cmd.CmdFuncV1(c)
 		b.checkCmdError(err, c)
 		if message != "" {
-			b.handlers.Response(c.Channel, message, c.User)
+			b.SendMessage(c.Channel, message, c.User)
 		}
 	case v2:
 		result, err := cmd.CmdFuncV2(c)
@@ -232,7 +232,7 @@ func (b *Bot) handleCmd(c *Cmd) {
 		}
 
 		if result.Message != "" {
-			b.handlers.Response(result.Channel, result.Message, c.User)
+			b.SendMessage(result.Channel, result.Message, c.User)
 		}
 	case v3:
 		result, err := cmd.CmdFuncV3(c)
@@ -244,7 +244,7 @@ func (b *Bot) handleCmd(c *Cmd) {
 			select {
 			case message := <-result.Message:
 				if message != "" {
-					b.handlers.Response(result.Channel, message, c.User)
+					b.SendMessage(result.Channel, message, c.User)
 				}
 			case <-result.Done:
 				return
@@ -257,6 +257,6 @@ func (b *Bot) checkCmdError(err error, c *Cmd) {
 	if err != nil {
 		errorMsg := fmt.Sprintf(errorExecutingCommand, c.Command, err.Error())
 		log.Printf(errorMsg)
-		b.handlers.Response(c.Channel, errorMsg, c.User)
+		b.SendMessage(c.Channel, errorMsg, c.User)
 	}
 }

--- a/help.go
+++ b/help.go
@@ -31,9 +31,9 @@ func (b *Bot) help(c *Cmd) {
 
 func (b *Bot) showHelp(c *Cmd, help *customCommand) {
 	if help.Description != "" {
-		b.handlers.Response(c.Channel, fmt.Sprintf(helpDescripton, help.Description), c.User)
+		b.SendMessage(c.Channel, fmt.Sprintf(helpDescripton, help.Description), c.User)
 	}
-	b.handlers.Response(c.Channel, fmt.Sprintf(helpUsage, CmdPrefix, c.Command, help.ExampleArgs), c.User)
+	b.SendMessage(c.Channel, fmt.Sprintf(helpUsage, CmdPrefix, c.Command, help.ExampleArgs), c.User)
 }
 
 func (b *Bot) showAvailabeCommands(channel string, sender *User) {
@@ -41,6 +41,6 @@ func (b *Bot) showAvailabeCommands(channel string, sender *User) {
 	for k := range commands {
 		cmds = append(cmds, k)
 	}
-	b.handlers.Response(channel, fmt.Sprintf(helpAboutCommand, CmdPrefix), sender)
-	b.handlers.Response(channel, fmt.Sprintf(availableCommands, strings.Join(cmds, ", ")), sender)
+	b.SendMessage(channel, fmt.Sprintf(helpAboutCommand, CmdPrefix), sender)
+	b.SendMessage(channel, fmt.Sprintf(availableCommands, strings.Join(cmds, ", ")), sender)
 }

--- a/irc/irc.go
+++ b/irc/irc.go
@@ -90,6 +90,9 @@ func onWelcome(e *ircevent.Event) {
 	}
 }
 
+// SetUp returns a bot for irc according to the Config, but does not run it.
+// When you are ready to run the bot, call Run(nil).
+// This is useful if you need a pointer to the bot, otherwise you can simply call Run().
 func SetUp(c *Config) *bot.Bot {
 	config = c
 

--- a/irc/irc.go
+++ b/irc/irc.go
@@ -90,9 +90,7 @@ func onWelcome(e *ircevent.Event) {
 	}
 }
 
-// Run reads the Config, connect to the specified IRC server and starts the bot.
-// The bot will automatically join all the channels specified in the configuration
-func Run(c *Config) {
+func SetUp(c *Config) *bot.Bot {
 	config = c
 
 	ircConn = ircevent.IRC(c.User, c.Nick)
@@ -111,7 +109,17 @@ func Run(c *Config) {
 	ircConn.AddCallback("PRIVMSG", onPRIVMSG)
 	ircConn.AddCallback("CTCP_ACTION", onCTCPACTION)
 
-	err := ircConn.Connect(c.Server)
+	return b
+}
+
+// Run reads the Config, connect to the specified IRC server and starts the bot.
+// The bot will automatically join all the channels specified in the configuration
+func Run(c *Config) {
+	if c != nil {
+		SetUp(c)
+	}
+
+	err := ircConn.Connect(config.Server)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This makes it possible to use the bot to send notifications about things happening outside the visibility of the bot's own commands. `go-chat-bot` provides nice abstractions for sending messages to IRC or Slack, it's just hard to get at the raw send function because it's not exported.

So this adds Bot.SendUnsolicitedMessage that can easily be called by any other code in a larger program to send some notification. It also makes it possible to get a hold of the bot instance by adding an `irc.SetUp()` func returning the bot that can optionally be called before irc.Run().

Only modified the IRC package for now, will modify the others if the concept / PR receives positive feedback.