### PR TITLE
Fix race condition

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -34,11 +34,6 @@ type responseMessage struct {
 	sender          *User
 }
 
-type errorMessage struct {
-	msg string
-	err error
-}
-
 // ResponseHandler must be implemented by the protocol to handle the bot responses
 type ResponseHandler func(target, message string, sender *User)
 
@@ -51,16 +46,14 @@ type Handlers struct {
 	Errored  ErrorHandler
 }
 
-// LogErrorHandler is a default error handler which logs all the errors
-// if the protocol does not specify a custom error handler
-func LogErrorHandler(msg string, err error) {
+func logErrorHandler(msg string, err error) {
 	log.Printf("%s: %s", msg, err.Error())
 }
 
 // New configures a new bot instance
 func New(h *Handlers) *Bot {
 	if h.Errored == nil {
-		h.Errored = LogErrorHandler
+		h.Errored = logErrorHandler
 	}
 
 	b := &Bot{

--- a/cmd.go
+++ b/cmd.go
@@ -1,8 +1,8 @@
 package bot
 
 import (
+	"errors"
 	"fmt"
-	"log"
 	"sync"
 )
 
@@ -213,14 +213,14 @@ func (b *Bot) executePassiveCommands(cmd *PassiveCmd) {
 			case pv1:
 				result, err := cmdFunc.PassiveFuncV1(cmd)
 				if err != nil {
-					log.Println(err)
+					b.errored(fmt.Sprintf("Error executing %s", cmdFunc.Cmd), err)
 				} else {
 					b.SendMessage(cmd.Channel, result, cmd.User)
 				}
 			case pv2:
 				result, err := cmdFunc.PassiveFuncV2(cmd)
 				if err != nil {
-					log.Println(err)
+					b.errored(fmt.Sprintf("Error executing %s", cmdFunc.Cmd), err)
 					return
 				}
 				for {
@@ -253,7 +253,7 @@ func (b *Bot) handleCmd(c *Cmd) {
 	cmd := commands[c.Command]
 
 	if cmd == nil {
-		log.Printf("Command not found %v", c.Command)
+		b.errored(fmt.Sprintf("Command not found %v", c.Command), errors.New("Command not found"))
 		return
 	}
 
@@ -296,7 +296,7 @@ func (b *Bot) handleCmd(c *Cmd) {
 func (b *Bot) checkCmdError(err error, c *Cmd) {
 	if err != nil {
 		errorMsg := fmt.Sprintf(errorExecutingCommand, c.Command, err.Error())
-		log.Printf(errorMsg)
+		b.errored(errorMsg, err)
 		b.SendMessage(c.Channel, errorMsg, c.User)
 	}
 }

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -7,12 +7,16 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 )
 
 var (
-	channel string
-	replies []string
-	user    *User
+	channel   string
+	replies   chan string
+	cmdError  chan string
+	user      *User
+	msgs      []string
+	lastError string
 )
 
 const (
@@ -22,27 +26,48 @@ const (
 	cmdExampleArgs = "arg1 arg2"
 )
 
+func waitMessages(t *testing.T, count int) {
+	for {
+		select {
+		case reply := <-replies:
+			msgs = append(msgs, reply)
+		case err := <-cmdError:
+			lastError = err
+		case <-time.After(1 * time.Second):
+			t.Fatal("Timed the shit out")
+		}
+		if len(msgs) == count {
+			return
+		}
+	}
+}
+
 func responseHandler(target string, message string, sender *User) {
 	channel = target
 	user = sender
-	replies = append(replies, message)
+	replies <- message
 }
 
-func resetResponses() {
+func errorHandler(msg string, err error) {
+	cmdError <- fmt.Sprintf("%s: %s", msg, err)
+}
+
+func reset() {
 	channel = ""
 	user = &User{Nick: ""}
-	replies = []string{}
+	replies = make(chan string, 10)
+	cmdError = make(chan string, 1)
+	msgs = []string{}
+	lastError = ""
 	commands = make(map[string]*customCommand)
+	periodicCommands = make(map[string]PeriodicConfig)
 }
 
 func newBot() *Bot {
 	return New(&Handlers{
 		Response: responseHandler,
+		Errored:  errorHandler,
 	})
-}
-
-func resetRegisteredPeriodicCommands() {
-	periodicCommands = make(map[string]PeriodicConfig)
 }
 
 func registerValidCommand() {
@@ -53,8 +78,7 @@ func registerValidCommand() {
 }
 
 func TestPeriodicCommands(t *testing.T) {
-	resetResponses()
-	resetRegisteredPeriodicCommands()
+	reset()
 	RegisterPeriodicCommand("morning",
 		PeriodicConfig{
 			CronSpec: "0 0 08 * * mon-fri",
@@ -62,7 +86,6 @@ func TestPeriodicCommands(t *testing.T) {
 			CmdFunc:  func(channel string) (string, error) { return "ok " + channel, nil },
 		})
 	b := New(&Handlers{Response: responseHandler})
-	b.synchronousMessageSending = true
 	defer b.Close()
 
 	entries := b.cron.Entries()
@@ -75,17 +98,14 @@ func TestPeriodicCommands(t *testing.T) {
 
 	entries[0].Job.Run()
 
-	if len(replies) != 1 {
-		t.Fatal("Should have one reply in the channel")
-	}
-	if replies[0] != "ok #channel" {
+	waitMessages(t, 1)
+
+	if msgs[0] != "ok #channel" {
 		t.Fatal("Invalid reply")
 	}
 }
-
 func TestMultiplePeriodicCommands(t *testing.T) {
-	resetResponses()
-	resetRegisteredPeriodicCommands()
+	reset()
 	RegisterPeriodicCommand("morning",
 		PeriodicConfig{
 			CronSpec: "0 0 08 * * mon-fri",
@@ -99,7 +119,6 @@ func TestMultiplePeriodicCommands(t *testing.T) {
 			CmdFunc:  func(channel string) (string, error) { return "ok_afternoon " + channel, nil },
 		})
 	b := New(&Handlers{Response: responseHandler})
-	b.synchronousMessageSending = true
 	defer b.Close()
 
 	entries := b.cron.Entries()
@@ -116,28 +135,29 @@ func TestMultiplePeriodicCommands(t *testing.T) {
 	entries[0].Job.Run()
 	entries[1].Job.Run()
 
-	if len(replies) != 2 {
+	waitMessages(t, 2)
+
+	if len(msgs) != 2 {
 		t.Fatal("Should have two replies in the channel")
 	}
-	if replies[0] != "ok_morning #channel" {
-		t.Fatal("Invalid reply in first cron job")
+	sort.Strings(msgs)
+	if msgs[0] != "ok_afternoon #channel" {
+		t.Fatal("Invalid reply in afternoon cron job")
 	}
-	if replies[1] != "ok_afternoon #channel" {
-		t.Fatal("Invalid reply in second cron job")
+	if msgs[1] != "ok_morning #channel" {
+		t.Fatalf("Invalid reply in morning cron job.")
 	}
 }
 
 func TestErroredPeriodicCommand(t *testing.T) {
-	resetResponses()
-	resetRegisteredPeriodicCommands()
+	reset()
 	RegisterPeriodicCommand("bugged",
 		PeriodicConfig{
 			CronSpec: "0 0 08 * * mon-fri",
 			Channels: []string{"#channel"},
 			CmdFunc:  func(channel string) (string, error) { return "bug", errors.New("error") },
 		})
-	b := New(&Handlers{Response: responseHandler})
-	b.synchronousMessageSending = true
+	b := newBot()
 	defer b.Close()
 
 	entries := b.cron.Entries()
@@ -147,19 +167,17 @@ func TestErroredPeriodicCommand(t *testing.T) {
 	}
 
 	entries[0].Job.Run()
+	waitMessages(t, 0)
 
-	if len(replies) != 0 {
+	if len(msgs) != 0 {
 		t.Fatal("Should not have a reply in the channel")
 	}
 }
 
 func TestDisabledCommands(t *testing.T) {
-	resetResponses()
+	reset()
 	commands = make(map[string]*customCommand)
-	b := New(&Handlers{
-		Response: responseHandler,
-	})
-	b.synchronousMessageSending = true
+	b := newBot()
 
 	RegisterCommand("cmd", "", "",
 		func(c *Cmd) (string, error) {
@@ -173,51 +191,52 @@ func TestDisabledCommands(t *testing.T) {
 
 	b.Disable([]string{"cmd"})
 	b.MessageReceived(&ChannelData{Channel: "#go-bot"}, &Message{Text: "!cmd"}, &User{Nick: "user"})
-	if len(replies) != 0 {
+
+	time.Sleep(100)
+	if len(msgs) != 0 {
 		t.Fatal("Should not execute disabled active commands")
 	}
 
 	b.Disable([]string{"passive"})
 	b.MessageReceived(&ChannelData{Channel: "#go-bot"}, &Message{Text: "regular message"}, &User{Nick: "user"})
 
-	if len(replies) != 0 {
+	time.Sleep(100)
+	if len(msgs) != 0 {
 		t.Fatal("Should not execute disabled passive commands")
 	}
 }
 
 func TestCommandNotRegistered(t *testing.T) {
-	resetResponses()
-
+	reset()
 	b := newBot()
-	b.synchronousMessageSending = true
 	b.MessageReceived(&ChannelData{Channel: "#go-bot"}, &Message{Text: "!not_a_cmd"}, &User{})
 
-	if len(replies) != 0 {
+	time.Sleep(100)
+
+	if len(msgs) != 0 {
 		t.Fatal("Should not reply if a command is not found")
 	}
 }
 
 func TestInvalidCmdArgs(t *testing.T) {
-	resetResponses()
+	reset()
 	registerValidCommand()
 
 	b := newBot()
-	b.synchronousMessageSending = true
 	b.MessageReceived(&ChannelData{Channel: "#go-bot"}, &Message{Text: "!cmd \"invalid arg"}, &User{Nick: "user"})
+
+	waitMessages(t, 1)
 
 	if channel != "#go-bot" {
 		t.Error("Should reply to #go-bot channel")
 	}
-	if len(replies) != 1 {
-		t.Fatal("Invalid reply")
-	}
-	if !strings.HasPrefix(replies[0], "Error parsing") {
+	if !strings.HasPrefix(msgs[0], "Error parsing") {
 		t.Fatal("Should reply with an error message")
 	}
 }
 
 func TestErroredCmd(t *testing.T) {
-	resetResponses()
+	reset()
 	cmdError := errors.New("error")
 	RegisterCommand("cmd", "", "",
 		func(c *Cmd) (string, error) {
@@ -225,35 +244,31 @@ func TestErroredCmd(t *testing.T) {
 		})
 
 	b := newBot()
-	b.synchronousMessageSending = true
 	b.MessageReceived(&ChannelData{Channel: "#go-bot"}, &Message{Text: "!cmd"}, &User{Nick: "user"})
+
+	waitMessages(t, 1)
 
 	if channel != "#go-bot" {
 		t.Fatal("Invalid channel")
 	}
-	if len(replies) != 1 {
-		t.Fatal("Invalid reply")
-	}
-	if replies[0] != fmt.Sprintf(errorExecutingCommand, "cmd", cmdError.Error()) {
+	if msgs[0] != fmt.Sprintf(errorExecutingCommand, "cmd", cmdError.Error()) {
 		t.Fatal("Reply should contain the error message")
 	}
 }
 
 func TestValidCmdOnChannel(t *testing.T) {
-	resetResponses()
+	reset()
 	registerValidCommand()
 
 	b := newBot()
-	b.synchronousMessageSending = true
 	b.MessageReceived(&ChannelData{Channel: "#go-bot"}, &Message{Text: "!cmd"}, &User{Nick: "user"})
+
+	waitMessages(t, 1)
 
 	if channel != "#go-bot" {
 		t.Fatal("Command called on channel should reply to channel")
 	}
-	if len(replies) != 1 {
-		t.Fatal("Should have one reply on channel")
-	}
-	if replies[0] != expectedMsg {
+	if msgs[0] != expectedMsg {
 		t.Fatal("Invalid command reply")
 	}
 }
@@ -270,29 +285,31 @@ func TestChannelData(t *testing.T) {
 }
 
 func TestHelpWithNoArgs(t *testing.T) {
-	resetResponses()
+	reset()
 	registerValidCommand()
 	b := newBot()
-	b.synchronousMessageSending = true
 	b.MessageReceived(&ChannelData{Channel: "#go-bot"}, &Message{Text: "!help"}, &User{Nick: "user"})
+
+	waitMessages(t, 2)
 
 	expectedReply := []string{
 		fmt.Sprintf(helpAboutCommand, CmdPrefix),
 		fmt.Sprintf(availableCommands, "cmd"),
 	}
 
-	if !reflect.DeepEqual(replies, expectedReply) {
-		t.Fatalf("Invalid reply. Expected %v got %v", expectedReply, replies)
+	if !reflect.DeepEqual(msgs, expectedReply) {
+		t.Fatalf("Invalid reply. Expected %v got %v", expectedReply, msgs)
 	}
 }
 
 func TestDisableHelp(t *testing.T) {
-	resetResponses()
+	reset()
 	registerValidCommand()
 	b := newBot()
-	b.synchronousMessageSending = true
 	b.Disable([]string{"help"})
 	b.MessageReceived(&ChannelData{Channel: "#go-bot"}, &Message{Text: "!help"}, &User{Nick: "user"})
+
+	time.Sleep(100)
 
 	if len(replies) > 0 {
 		t.Fatalf("Should not execute help after disabling it")
@@ -300,27 +317,27 @@ func TestDisableHelp(t *testing.T) {
 }
 
 func TestHelpForACommand(t *testing.T) {
-	resetResponses()
+	reset()
 	registerValidCommand()
 	b := newBot()
-	b.synchronousMessageSending = true
 	b.MessageReceived(&ChannelData{Channel: "#go-bot"}, &Message{Text: "!help cmd"}, &User{Nick: "user"})
+
+	waitMessages(t, 2)
 
 	expectedReply := []string{
 		fmt.Sprintf(helpDescripton, cmdDescription),
 		fmt.Sprintf(helpUsage, CmdPrefix, cmd, cmdExampleArgs),
 	}
 
-	if !reflect.DeepEqual(replies, expectedReply) {
-		t.Fatalf("Invalid reply. Expected %v got %v", expectedReply, replies)
+	if !reflect.DeepEqual(msgs, expectedReply) {
+		t.Fatalf("Invalid reply. Expected %v got %v", expectedReply, msgs)
 	}
 }
 
 func TestHelpWithNonExistingCommand(t *testing.T) {
-	resetResponses()
+	reset()
 	registerValidCommand()
 	b := newBot()
-	b.synchronousMessageSending = true
 	b.MessageReceived(&ChannelData{Channel: "#go-bot"}, &Message{Text: "!help not_a_cmd"}, &User{Nick: "user"})
 
 	expectedReply := []string{
@@ -328,28 +345,28 @@ func TestHelpWithNonExistingCommand(t *testing.T) {
 		fmt.Sprintf(availableCommands, "cmd"),
 	}
 
-	if !reflect.DeepEqual(replies, expectedReply) {
-		t.Fatalf("Invalid reply. Expected %v got %v", expectedReply, replies)
+	waitMessages(t, 2)
+
+	if !reflect.DeepEqual(msgs, expectedReply) {
+		t.Fatalf("Invalid reply. Expected %v got %v", expectedReply, msgs)
 	}
 }
 
 func TestHelpWithInvalidArgs(t *testing.T) {
-	resetResponses()
+	reset()
 	registerValidCommand()
 	b := newBot()
-	b.synchronousMessageSending = true
 	b.MessageReceived(&ChannelData{Channel: "#go-bot"}, &Message{Text: "!help cmd \"invalid arg"}, &User{Nick: "user"})
 
-	if len(replies) != 1 {
-		t.Fatal("Invalid reply")
-	}
-	if !strings.HasPrefix(replies[0], "Error parsing") {
+	waitMessages(t, 1)
+
+	if !strings.HasPrefix(msgs[0], "Error parsing") {
 		t.Fatal("Should reply with an error message")
 	}
 }
 
 func TestCmdV2(t *testing.T) {
-	resetResponses()
+	reset()
 	RegisterCommandV2("cmd", "", "",
 		func(c *Cmd) (CmdResult, error) {
 			return CmdResult{
@@ -358,27 +375,29 @@ func TestCmdV2(t *testing.T) {
 		})
 
 	b := newBot()
-	b.synchronousMessageSending = true
 	b.MessageReceived(&ChannelData{Channel: "#go-bot"}, &Message{Text: "!cmd"}, &User{Nick: "user"})
+
+	waitMessages(t, 1)
 
 	if channel != "#channel" {
 		t.Error("Wrong channel")
 	}
-	if !reflect.DeepEqual([]string{"message"}, replies) {
+	if !reflect.DeepEqual([]string{"message"}, msgs) {
 		t.Error("Invalid reply")
 	}
 }
 
 func TestCmdV2WithoutSpecifyingChannel(t *testing.T) {
-	resetResponses()
+	reset()
 	RegisterCommandV2("cmd", "", "",
 		func(c *Cmd) (CmdResult, error) {
 			return CmdResult{Message: "message"}, nil
 		})
 
 	b := newBot()
-	b.synchronousMessageSending = true
 	b.MessageReceived(&ChannelData{Channel: "#go-bot"}, &Message{Text: "!cmd"}, &User{Nick: "user"})
+
+	waitMessages(t, 1)
 
 	if channel != "#go-bot" {
 		t.Error("Should reply to original channel if no channel is returned")
@@ -386,46 +405,39 @@ func TestCmdV2WithoutSpecifyingChannel(t *testing.T) {
 }
 
 func TestPassiveCommand(t *testing.T) {
-	resetResponses()
-
+	reset()
 	passiveCommands = make(map[string]*customCommand)
-
-	echo := func(cmd *PassiveCmd) (string, error) {
-		return cmd.Raw, nil
-	}
-	ping := func(cmd *PassiveCmd) (string, error) {
-		return "pong", nil
-	}
-	errored := func(cmd *PassiveCmd) (string, error) {
-		return "", errors.New("error")
-	}
+	echo := func(cmd *PassiveCmd) (string, error) { return cmd.Raw, nil }
+	ping := func(cmd *PassiveCmd) (string, error) { return "pong", nil }
+	errored := func(cmd *PassiveCmd) (string, error) { return "", errors.New("error") }
 
 	RegisterPassiveCommand("echo", echo)
 	RegisterPassiveCommand("ping", ping)
 	RegisterPassiveCommand("errored", errored)
 
 	b := newBot()
-	b.synchronousMessageSending = true
 	b.MessageReceived(&ChannelData{Channel: "#go-bot"}, &Message{Text: "test"}, &User{Nick: "user"})
+
+	waitMessages(t, 2)
 
 	if channel != "#go-bot" {
 		t.Error("Invalid channel")
 	}
-	if len(replies) != 2 {
+	if len(msgs) != 2 {
 		t.Fatal("Invalid reply")
 	}
 
-	sort.Strings(replies)
-	if replies[0] != "pong" {
+	sort.Strings(msgs)
+	if msgs[0] != "pong" {
 		t.Error("ping command not executed")
 	}
-	if replies[1] != "test" {
+	if msgs[1] != "test" {
 		t.Error("echo command not executed")
 	}
 }
 
 func TestCmdV3(t *testing.T) {
-	resetResponses()
+	reset()
 	result := CmdResultV3{
 		Channel: "#channel",
 		Message: make(chan string),
@@ -436,21 +448,22 @@ func TestCmdV3(t *testing.T) {
 		})
 
 	b := newBot()
-	b.synchronousMessageSending = true
 	go b.MessageReceived(&ChannelData{Channel: "#go-bot"}, &Message{Text: "!cmd"}, &User{Nick: "user"})
 	result.Message <- "message"
 	result.Done <- true
 
+	waitMessages(t, 1)
+
 	if channel != "#channel" {
 		t.Error("Wrong channel")
 	}
-	if !reflect.DeepEqual([]string{"message"}, replies) {
+	if !reflect.DeepEqual([]string{"message"}, msgs) {
 		t.Error("Invalid reply")
 	}
 }
 
 func TestCmdV3WithoutSpecifyingChannel(t *testing.T) {
-	resetResponses()
+	reset()
 	result := CmdResultV3{
 		Message: make(chan string),
 		Done:    make(chan bool)}
@@ -460,15 +473,16 @@ func TestCmdV3WithoutSpecifyingChannel(t *testing.T) {
 		})
 
 	b := newBot()
-	b.synchronousMessageSending = true
 	go b.MessageReceived(&ChannelData{Channel: "#go-bot"}, &Message{Text: "!cmd"}, &User{Nick: "user"})
 	result.Message <- "message"
 	result.Done <- true
 
+	waitMessages(t, 1)
+
 	if channel != "#go-bot" {
 		t.Error("Should reply to original channel if no channel is returned")
 	}
-	if !reflect.DeepEqual([]string{"message"}, replies) {
+	if !reflect.DeepEqual([]string{"message"}, msgs) {
 		t.Error("Invalid reply")
 	}
 }

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -34,7 +34,10 @@ func waitMessages(t *testing.T, count int, errorCount int) {
 		case err := <-cmdError:
 			errs = append(errs, err)
 		case <-time.After(1 * time.Second):
-			t.Fatal("Timed the shit out")
+			t.Error("Timeout waiting for messages")
+			t.Errorf("msgs received: %v", msgs)
+			t.Errorf("errs received: %v", errs)
+			t.Fatal()
 		}
 		if len(msgs) == count && len(errs) == errorCount {
 			return

--- a/slack/slack.go
+++ b/slack/slack.go
@@ -8,6 +8,8 @@ import (
 	"github.com/nlopes/slack"
 )
 
+// MessageFilter allows implementing a filter function to transform the messages
+// before sending to the channel, it is run before the bot sends the message to slack
 type MessageFilter func(string, *bot.User) (string, slack.PostMessageParameters)
 
 var (
@@ -105,6 +107,8 @@ func ownMessage(UserID string) bool {
 	return botUserID == UserID
 }
 
+// RunWithFilter executes the bot and sets up a message filter which will
+// receive all the messages before they are sent to slack
 func RunWithFilter(token string, customMessageFilter MessageFilter) {
 	if customMessageFilter == nil {
 		panic("A valid message filter must be provided.")

--- a/telegram/telegram.go
+++ b/telegram/telegram.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/go-chat-bot/bot"
-	"gopkg.in/telegram-bot-api.v3"
+	tgbotapi "gopkg.in/telegram-bot-api.v3"
 )
 
 var (
@@ -21,7 +21,6 @@ func responseHandler(target string, message string, sender *bot.User) {
 		return
 	}
 	msg := tgbotapi.NewMessage(id, message)
-	msg.ReplyToMessageID = msg.ReplyToMessageID
 
 	tg.Send(msg)
 }


### PR DESCRIPTION
@toolateforteddy there was a race condition writing to the response handler. As this function is implemented by various protocols and we can't be sure if they can handle multiple messages and how fast they are, I've made 2 changes:

- Added a mutex to write one message at a time, so the messages will be queued and sent synchronously to the protocols
- Changed the buffer length to 100 as the messages are mostly like text and I don't thing that having a 100 message on the buffer will cause any issues