### PR TITLE
Add Case Insensitivity to commands

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,6 @@ jobs:
       - image: circleci/golang:1.11
         environment:
           GO111MODULE: "on"      
-          COVERALLS_TOKEN: $COVERALLS_TOKEN
     working_directory: /go/src/github.com/go-chat-bot/bot
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ jobs:
       - image: circleci/golang:1.11
         environment:
           GO111MODULE: "on"      
+          COVERALLS_TOKEN: $COVERALLS_TOKEN
     working_directory: /go/src/github.com/go-chat-bot/bot
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,4 +10,4 @@ jobs:
       - checkout
       - run: go test -v -cover -race -coverprofile=coverage.out          
       - run: go get github.com/mattn/goveralls
-      - run: goveralls -coverprofile=coverage.out -service=circle-ci
+      - run: goveralls -coverprofile=coverage.out -service=circle-ci -repotoken=$COVERALLS_TOKEN

--- a/parser.go
+++ b/parser.go
@@ -35,7 +35,7 @@ func parse(s string, channel *ChannelData, user *User) (*Cmd, error) {
 
 	// get the command
 	pieces := strings.SplitN(c.Message, " ", 2)
-	c.Command = pieces[0]
+	c.Command = strings.ToLower(pieces[0])
 
 	if len(pieces) > 1 {
 		// get the arguments and remove extra spaces

--- a/parser_test.go
+++ b/parser_test.go
@@ -87,59 +87,61 @@ func TestParser(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		cmd, _ := parse(test.msg, channel, user)
-		if test.expected != nil && cmd != nil {
-			if test.expected.Raw != cmd.Raw {
-				t.Errorf("Expected Raw:\n%#v\ngot:\n%#v", test.expected.Raw, cmd.Raw)
-			}
-			if test.expected.Channel != cmd.Channel {
-				t.Errorf("Expected Channel:\n%#v\ngot:\n%#v", test.expected.Channel, cmd.Channel)
-			}
-			if test.expected.Message != cmd.Message {
-				t.Errorf("Expected Message:\n%#v\ngot:\n%#v", test.expected.Message, cmd.Message)
-			}
-			if test.expected.Command != cmd.Command {
-				t.Errorf("Expected Command:\n%#v\ngot:\n%#v", test.expected.Command, cmd.Command)
-			}
-			if test.expected.RawArgs != cmd.RawArgs {
-				t.Errorf("Expected RawArgs:\n%#v\ngot:\n%#v", test.expected.RawArgs, cmd.RawArgs)
-			}
-			if test.expected.ChannelData.Protocol != cmd.ChannelData.Protocol {
-				t.Errorf("Expected ChannelData.Protocol:\n%#v\ngot:\n%#v", test.expected.ChannelData.Protocol, cmd.ChannelData.Protocol)
-			}
-			if test.expected.ChannelData.Server != cmd.ChannelData.Server {
-				t.Errorf("Expected ChannelData.Server:\n%#v\ngot:\n%#v", test.expected.ChannelData.Server, cmd.ChannelData.Server)
-			}
-			if test.expected.ChannelData.Channel != cmd.ChannelData.Channel {
-				t.Errorf("Expected ChannelData.Channel:\n%#v\ngot:\n%#v", test.expected.ChannelData.Channel, cmd.ChannelData.Channel)
-			}
-			if test.expected.ChannelData.IsPrivate != cmd.ChannelData.IsPrivate {
-				t.Errorf("Expected ChannelData.IsPrivate:\n%#v\ngot:\n%#v", test.expected.ChannelData.IsPrivate, cmd.ChannelData.IsPrivate)
-			}
-			if test.expected.User.ID != cmd.User.ID {
-				t.Errorf("Expected User.ID:\n%#v\ngot:\n%#v", test.expected.User.ID, cmd.User.ID)
-			}
-			if test.expected.User.Nick != cmd.User.Nick {
-				t.Errorf("Expected User.Nick:\n%#v\ngot:\n%#v", test.expected.User.Nick, cmd.User.Nick)
-			}
-			if test.expected.User.RealName != cmd.User.RealName {
-				t.Errorf("Expected User.RealName:\n%#v\ngot:\n%#v", test.expected.User.RealName, cmd.User.RealName)
-			}
-			if test.expected.User.IsBot != cmd.User.IsBot {
-				t.Errorf("Expected User.IsBot:\n%#v\ngot:\n%#v", test.expected.User.IsBot, cmd.User.IsBot)
-			}
-			if test.expected.MessageData.Text != cmd.MessageData.Text {
-				t.Errorf("Expected MessageData.Text:\n%#v\ngot:\n%#v", test.expected.MessageData.Text, cmd.MessageData.Text)
-			}
-			if test.expected.MessageData.IsAction != cmd.MessageData.IsAction {
-				t.Errorf("Expected MessageData.IsAction:\n%#v\ngot:\n%#v", test.expected.MessageData.IsAction, cmd.MessageData.IsAction)
-			}
-			for i, arg := range test.expected.Args {
-				if arg != cmd.Args[i] {
-					t.Errorf("Expected cmd.Args[]:\n%#v\ngot:\n%#v", arg, cmd.Args[i])
+		t.Run(test.msg, func(t *testing.T) {
+			cmd, _ := parse(test.msg, channel, user)
+			if test.expected != nil && cmd != nil {
+				if test.expected.Raw != cmd.Raw {
+					t.Errorf("Expected Raw:\n%#v\ngot:\n%#v", test.expected.Raw, cmd.Raw)
+				}
+				if test.expected.Channel != cmd.Channel {
+					t.Errorf("Expected Channel:\n%#v\ngot:\n%#v", test.expected.Channel, cmd.Channel)
+				}
+				if test.expected.Message != cmd.Message {
+					t.Errorf("Expected Message:\n%#v\ngot:\n%#v", test.expected.Message, cmd.Message)
+				}
+				if test.expected.Command != cmd.Command {
+					t.Errorf("Expected Command:\n%#v\ngot:\n%#v", test.expected.Command, cmd.Command)
+				}
+				if test.expected.RawArgs != cmd.RawArgs {
+					t.Errorf("Expected RawArgs:\n%#v\ngot:\n%#v", test.expected.RawArgs, cmd.RawArgs)
+				}
+				if test.expected.ChannelData.Protocol != cmd.ChannelData.Protocol {
+					t.Errorf("Expected ChannelData.Protocol:\n%#v\ngot:\n%#v", test.expected.ChannelData.Protocol, cmd.ChannelData.Protocol)
+				}
+				if test.expected.ChannelData.Server != cmd.ChannelData.Server {
+					t.Errorf("Expected ChannelData.Server:\n%#v\ngot:\n%#v", test.expected.ChannelData.Server, cmd.ChannelData.Server)
+				}
+				if test.expected.ChannelData.Channel != cmd.ChannelData.Channel {
+					t.Errorf("Expected ChannelData.Channel:\n%#v\ngot:\n%#v", test.expected.ChannelData.Channel, cmd.ChannelData.Channel)
+				}
+				if test.expected.ChannelData.IsPrivate != cmd.ChannelData.IsPrivate {
+					t.Errorf("Expected ChannelData.IsPrivate:\n%#v\ngot:\n%#v", test.expected.ChannelData.IsPrivate, cmd.ChannelData.IsPrivate)
+				}
+				if test.expected.User.ID != cmd.User.ID {
+					t.Errorf("Expected User.ID:\n%#v\ngot:\n%#v", test.expected.User.ID, cmd.User.ID)
+				}
+				if test.expected.User.Nick != cmd.User.Nick {
+					t.Errorf("Expected User.Nick:\n%#v\ngot:\n%#v", test.expected.User.Nick, cmd.User.Nick)
+				}
+				if test.expected.User.RealName != cmd.User.RealName {
+					t.Errorf("Expected User.RealName:\n%#v\ngot:\n%#v", test.expected.User.RealName, cmd.User.RealName)
+				}
+				if test.expected.User.IsBot != cmd.User.IsBot {
+					t.Errorf("Expected User.IsBot:\n%#v\ngot:\n%#v", test.expected.User.IsBot, cmd.User.IsBot)
+				}
+				if test.expected.MessageData.Text != cmd.MessageData.Text {
+					t.Errorf("Expected MessageData.Text:\n%#v\ngot:\n%#v", test.expected.MessageData.Text, cmd.MessageData.Text)
+				}
+				if test.expected.MessageData.IsAction != cmd.MessageData.IsAction {
+					t.Errorf("Expected MessageData.IsAction:\n%#v\ngot:\n%#v", test.expected.MessageData.IsAction, cmd.MessageData.IsAction)
+				}
+				for i, arg := range test.expected.Args {
+					if arg != cmd.Args[i] {
+						t.Errorf("Expected cmd.Args[]:\n%#v\ngot:\n%#v", arg, cmd.Args[i])
+					}
 				}
 			}
-		}
+		})
 	}
 }
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -11,6 +11,9 @@ func TestParser(t *testing.T) {
 	cmdWithoutArgs := CmdPrefix + "cmd"
 	cmdWithArgs := CmdPrefix + "cmd    arg1  arg2   "
 	cmdWithQuotes := CmdPrefix + "cmd    \"arg1  arg2\""
+	cmdMixedCaseWithoutArgs := CmdPrefix + "Cmd"
+	cmdMixedCaseWithArgs := CmdPrefix + "Cmd    arg1  arg2   "
+	cmdMixedCaseWithQuotes := CmdPrefix + "Cmd    \"arg1  arg2\""
 
 	tests := []struct {
 		msg      string
@@ -49,6 +52,37 @@ func TestParser(t *testing.T) {
 			RawArgs:     "\"arg1  arg2\"",
 			Args:        []string{"arg1  arg2"},
 			MessageData: &Message{Text: strings.TrimLeft("cmd    \"arg1  arg2\"", CmdPrefix)},
+		}},
+		{cmdMixedCaseWithoutArgs, &Cmd{
+			Raw:         cmdMixedCaseWithoutArgs,
+			Command:     "cmd",
+			Channel:     channel.Channel,
+			ChannelData: channel,
+			User:        user,
+			Message:     "Cmd",
+			MessageData: &Message{Text: strings.TrimLeft("Cmd", CmdPrefix)},
+		}},
+		{cmdMixedCaseWithArgs, &Cmd{
+			Raw:         cmdMixedCaseWithArgs,
+			Command:     "cmd",
+			Channel:     channel.Channel,
+			ChannelData: channel,
+			User:        user,
+			Message:     "Cmd    arg1  arg2",
+			RawArgs:     "arg1  arg2",
+			Args:        []string{"arg1", "arg2"},
+			MessageData: &Message{Text: strings.TrimLeft("Cmd    arg1  arg2", CmdPrefix)},
+		}},
+		{cmdMixedCaseWithQuotes, &Cmd{
+			Raw:         cmdMixedCaseWithQuotes,
+			Command:     "cmd",
+			Channel:     channel.Channel,
+			ChannelData: channel,
+			User:        user,
+			Message:     "Cmd    \"arg1  arg2\"",
+			RawArgs:     "\"arg1  arg2\"",
+			Args:        []string{"arg1  arg2"},
+			MessageData: &Message{Text: strings.TrimLeft("Cmd    \"arg1  arg2\"", CmdPrefix)},
 		}},
 	}
 


### PR DESCRIPTION
Part 1 of #84. Does not fix the case of dealing with non-ansi characters to ansi characters. 