### PR TITLE
prefix switchable

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -3,18 +3,20 @@ package bot
 
 import (
 	"errors"
+	"github.com/robfig/cron"
 	"log"
 	"math/rand"
+	"os"
 	"time"
-
-	"github.com/robfig/cron"
 )
 
-const (
+var (
 	// CmdPrefix is the prefix used to identify a command.
 	// !hello would be identified as a command
 	CmdPrefix = "!"
+)
 
+const (
 	// MsgBuffer is the max number of messages which can be buffered
 	// while waiting to flush them to the chat service.
 	MsgBuffer = 100
@@ -125,9 +127,9 @@ func (b *Bot) MessageReceived(channel *ChannelData, message *Message, sender *Us
 // SendMessage queues a message for a target recipient, optionally from a particular sender.
 func (b *Bot) SendMessage(target string, message string, sender *User) {
 	message = b.executeFilterCommands(&FilterCmd{
-		Target: target,
+		Target:  target,
 		Message: message,
-		User: sender})
+		User:    sender})
 
 	select {
 	case b.msgsToSend <- responseMessage{target, message, sender}:
@@ -164,5 +166,9 @@ func (b *Bot) Close() {
 }
 
 func init() {
+	CmdPrefix = "!"
+	if prefix := os.Getenv("BOT_CMD_PREFIX"); prefix != "" {
+		CmdPrefix = prefix
+	}
 	rand.Seed(time.Now().UnixNano())
 }

--- a/debug/main.go
+++ b/debug/main.go
@@ -43,7 +43,7 @@ func main() {
 		Response: responseHandler,
 	})
 
-	fmt.Println("Type a command or !help for available commands...")
+	fmt.Printf("Type a command or %shelp for available commands...\n", bot.CmdPrefix)
 
 	for {
 		r := bufio.NewReader(os.Stdin)


### PR DESCRIPTION
Allow instances to specify the "BOT_CMD_PREFIX" before running. 
This is to address
https://github.com/go-chat-bot/bot/issues/42
https://github.com/go-chat-bot/bot/issues/6
Example:
```bash
   export TELEGRAM_TOKEN=....
   export BOT_CMD_PREFIX='/'
   mkdir testtel ; cd testtel
   cat <<"EOF" > main.go
package main
import (
    "os"
    "github.com/go-chat-bot/bot/telegram"
    _ "github.com/go-chat-bot/plugins/catfacts"
    _ "github.com/go-chat-bot/plugins/catgif"
    _ "github.com/go-chat-bot/plugins/chucknorris"
    // Import all the commands you wish to use
)
func main() {
    telegram.Run(os.Getenv("TELEGRAM_TOKEN"), os.Getenv("DEBUG") != "")
}
EOF
go build -a
./testtel
```