### PR TITLE
[irc] Add support for real name configuration

### DIFF
--- a/irc/irc.go
+++ b/irc/irc.go
@@ -16,6 +16,7 @@ type Config struct {
 	Channels      []string // Channels to connect. Ex: []string{"#go-bot", "#channel mypassword"}
 	User          string   // The IRC username the bot will use
 	Nick          string   // The nick the bot will use
+	RealName      string   // The real name (longer string) the bot will use
 	Password      string   // Server password
 	UseTLS        bool     // Should connect using TLS?
 	TLSServerName string   // Must supply if UseTLS is true
@@ -97,6 +98,7 @@ func SetUp(c *Config) *bot.Bot {
 	config = c
 
 	ircConn = ircevent.IRC(c.User, c.Nick)
+	ircConn.RealName = c.RealName
 	ircConn.Password = c.Password
 	ircConn.UseTLS = c.UseTLS
 	ircConn.TLSConfig = &tls.Config{


### PR DESCRIPTION
In addition to username and nick IRC also has real name information.
This can be longer string with URL to code repository for example.