### PR TITLE
Fix situation when message gets filtered out

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -140,6 +140,9 @@ func (b *Bot) SendMessage(target string, message string, sender *User) {
 		Target:  target,
 		Message: message,
 		User:    sender})
+	if message == "" {
+		return
+	}
 
 	select {
 	case b.msgsToSend <- responseMessage{target, message, sender}:


### PR DESCRIPTION
Original code tried to queue message for sending even if the filter
made the content empty. This was causing at least unpredictable tests
with TestFilterCommandSilence randomly failing