### PR TITLE
#97 add GetInstance() returning a singleton to expose b.SendMessage() to plugins

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -50,6 +50,16 @@ func logErrorHandler(msg string, err error) {
 	log.Printf("%s: %s", msg, err.Error())
 }
 
+var singleton *Bot
+
+// GetInstance hand back the Bot singleton
+func GetInstance() (*Bot, error) {
+	if singleton != nil {
+		return singleton, nil
+	}
+	return nil, errors.New("bot has not been initialized")
+}
+
 // New configures a new bot instance
 func New(h *Handlers) *Bot {
 	if h.Errored == nil {
@@ -68,6 +78,9 @@ func New(h *Handlers) *Bot {
 	go b.processMessages()
 
 	b.startPeriodicCommands()
+
+	// store the Bot in a singleton to hand it back to anyone else who comes asking
+	singleton = b
 	return b
 }
 

--- a/irc/irc.go
+++ b/irc/irc.go
@@ -6,9 +6,11 @@ import (
 	"log"
 	"strings"
 
-	"github.com/go-chat-bot/bot"
+	bot "github.com/bnfinet/go-chat-bot"
 	ircevent "github.com/thoj/go-ircevent"
 )
+
+// "github.com/go-chat-bot/bot"
 
 // Config must contain the necessary data to connect to an IRC server
 type Config struct {

--- a/telegram/telegram.go
+++ b/telegram/telegram.go
@@ -6,9 +6,12 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/go-chat-bot/bot"
+	bot "github.com/bnfinet/go-chat-bot"
+
 	tgbotapi "gopkg.in/telegram-bot-api.v3"
 )
+
+// "github.com/go-chat-bot/bot"
 
 var (
 	tg *tgbotapi.BotAPI


### PR DESCRIPTION
This seems like the most straight forward way to access `b.SendMessage()` directly from a plugin.

The use case is sending out messages which are triggered by events outside of the message stream.  My specific itch is notifying an IRC channel of a build on `docker-hub` after receiving a webhook.  So **events**, not responsive commands nor periodic commands. 

I'm happy to explore other solutions such as registering a function with an `Outbox`, but even in that case the call would be initiated from outside of `bot`.  Perhaps using a queue (or even kafka or redis pub/sub) would be better.