### PR TITLE
Update Slack Version Dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/martinusso/go-docs v0.0.0-20161215163720-81905d575a58 // indirect
 	github.com/mattn/go-shellwords v1.0.3
 	github.com/mozillazg/go-unidecode v0.1.0
-	github.com/nlopes/slack v0.4.0
+	github.com/nlopes/slack v0.5.0
 	github.com/pkg/errors v0.8.0 // indirect
 	github.com/pyinx/gorocket v0.0.0-20170810024322-78ae1353729f
 	github.com/robfig/cron v0.0.0-20180505203441-b41be1df6967


### PR DESCRIPTION
After we fixed the slack plugin to send in the right format, we
failed to update the module dependency to account for that.