### PR TITLE
Allow Protocol Argument Passing

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -202,24 +202,11 @@ func (b *Bot) MessageReceived(channel *ChannelData, message *Message, sender *Us
 
 // SendMessage queues a message for a target recipient, optionally from a particular sender.
 func (b *Bot) SendMessage(target string, message string, sender *User) {
-	message = b.executeFilterCommands(&FilterCmd{
+	b.SendMessageV2(OutgoingMessage{
 		Target:  target,
 		Message: message,
-		User:    sender,
+		Sender:  sender,
 	})
-	if message == "" {
-		return
-	}
-
-	select {
-	case b.msgsToSend <- responseMessage{
-		target:  target,
-		message: message,
-		sender:  sender,
-	}:
-	default:
-		b.errored("Failed to queue message to send.", errors.New("Too busy"))
-	}
 }
 
 // SendMessageV2 queues a message.
@@ -236,7 +223,7 @@ func (b *Bot) SendMessageV2(om OutgoingMessage) {
 	select {
 	case b.msgsToSend <- responseMessage{
 		target:      om.Target,
-		message:     om.Message,
+		message:     message,
 		sender:      om.Sender,
 		protoParams: om.ProtoParams,
 	}:

--- a/bot.go
+++ b/bot.go
@@ -58,6 +58,7 @@ type responseMessage struct {
 	protoParams     interface{}
 }
 
+// OutgoingMessage collects all the information for a message to go out.
 type OutgoingMessage struct {
 	Target      string
 	Message     string
@@ -221,7 +222,7 @@ func (b *Bot) SendMessage(target string, message string, sender *User) {
 	}
 }
 
-// SendMessage queues a message for a target recipient, optionally from a particular sender.
+// SendMessageV2 queues a message.
 func (b *Bot) SendMessageV2(om OutgoingMessage) {
 	message := b.executeFilterCommands(&FilterCmd{
 		Target:  om.Target,

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -56,8 +56,8 @@ func responseHandler(target string, message string, sender *User) {
 func responseHandlerV2(om OutgoingMessage) {
 	channel = om.Target
 	user = om.Sender
-	replies <- om.Message
 	protoParams = om.ProtoParams
+	replies <- om.Message
 }
 
 func errorHandler(msg string, err error) {

--- a/help.go
+++ b/help.go
@@ -14,7 +14,10 @@ const (
 )
 
 func (b *Bot) help(c *Cmd) {
-	cmd, _ := parse(CmdPrefix+c.RawArgs, c.ChannelData, c.User)
+	msg := &Message{
+		Text: CmdPrefix + c.RawArgs,
+	}
+	cmd, _ := parse(msg, c.ChannelData, c.User)
 	if cmd == nil {
 		b.showAvailabeCommands(c.Channel, c.User)
 		return

--- a/parser.go
+++ b/parser.go
@@ -13,21 +13,20 @@ var (
 	re = regexp.MustCompile("\\s+") // Matches one or more spaces
 )
 
-func parse(s string, channel *ChannelData, user *User) (*Cmd, error) {
-	c := &Cmd{Raw: s}
-	s = strings.TrimSpace(s)
+func parse(m *Message, channel *ChannelData, user *User) (*Cmd, error) {
+	s := strings.TrimSpace(m.Text)
 
 	if !strings.HasPrefix(s, CmdPrefix) {
 		return nil, nil
 	}
 
-	c.Channel = strings.TrimSpace(channel.Channel)
-	c.ChannelData = channel
-	c.User = user
-
-	// Trim the prefix and extra spaces
-	c.Message = strings.TrimPrefix(s, CmdPrefix)
-	c.Message = strings.TrimSpace(c.Message)
+	c := &Cmd{
+		Channel:     strings.TrimSpace(channel.Channel),
+		ChannelData: channel,
+		Message:     strings.TrimSpace(strings.TrimPrefix(s, CmdPrefix)),
+		Raw:         m.Text,
+		User:        user,
+	}
 
 	// check if we have the command and not only the prefix
 	if c.Message == "" {
@@ -48,9 +47,8 @@ func parse(s string, channel *ChannelData, user *User) (*Cmd, error) {
 		c.Args = parsedArgs
 	}
 
-	c.MessageData = &Message{
-		Text: c.Message,
-	}
+	m.Text = c.Message
+	c.MessageData = m
 
 	return c, nil
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -98,7 +98,7 @@ func TestParser(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.msg, func(t *testing.T) {
-			cmd, _ := parse(test.msg, channel, user)
+			cmd, _ := parse(&Message{Text: test.msg}, channel, user)
 			if test.expected != nil && cmd != nil {
 				if test.expected.Raw != cmd.Raw {
 					t.Errorf("Expected Raw:\n%#v\ngot:\n%#v", test.expected.Raw, cmd.Raw)
@@ -156,7 +156,11 @@ func TestParser(t *testing.T) {
 }
 
 func TestInvalidArguments(t *testing.T) {
-	cmd, err := parse("!cmd Invalid \"arg", &ChannelData{Channel: "#go-bot"}, &User{Nick: "user123"})
+	cmd, err := parse(
+		&Message{Text: "!cmd Invalid \"arg"},
+		&ChannelData{Channel: "#go-bot"},
+		&User{Nick: "user123"},
+	)
 	if err == nil {
 		t.Error("Expected error, got nil")
 	}


### PR DESCRIPTION
Due to the generic nature of this framework, platform specific
behaviors are hard to take advantage of. With this PR, protocol
plugins can offer additional information for message handlers to
read, and accept additional information as well.

In particular, this change was tested to allow a Slack response to
be made as a threaded reply, instead of only ever in the main channel.

EG:
```
func threadedEcho(cmd *bot.Cmd) (bot.CmdResult, error) {
	var params *slack.PostMessageParameters
	if ev, ok := cmd.MessageData.ProtoMsg.(*slack.MessageEvent); ok {
		params = &slack.PostMessageParameters{
			AsUser:          true,
			ThreadTimestamp: ev.Timestamp,
		}
	}
	return bot.CmdResult{
		Message:     fmt.Sprintf("%s: %s", cmd.User.Nick, cmd.Raw),
		Channel:     cmd.Channel,
		ProtoParams: params,
	}, nil
}
```