### PR TITLE
Use SendMessageV2 everywhere

### DIFF
--- a/google-chat/google-chat.go
+++ b/google-chat/google-chat.go
@@ -135,7 +135,10 @@ func Run(config *Config) {
 			case "ADDED_TO_SPACE":
 				if config.WelcomeMessage != "" {
 					log.Printf("Sending welcome message to %s\n", msg.Space.Name)
-					b.SendMessage(msg.Space.Name, config.WelcomeMessage, nil)
+					b.SendMessage(OutgoingMessage{
+						Target:  msg.Space.Name,
+						Message: config.WelcomeMessage,
+					})
 				}
 			case "REMOVED_FROM_SPACE":
 				break

--- a/help.go
+++ b/help.go
@@ -34,9 +34,17 @@ func (b *Bot) help(c *Cmd) {
 
 func (b *Bot) showHelp(c *Cmd, help *customCommand) {
 	if help.Description != "" {
-		b.SendMessage(c.Channel, fmt.Sprintf(helpDescripton, help.Description), c.User)
+		b.SendMessage(OutgoingMessage{
+			Target:  c.Channel,
+			Message: fmt.Sprintf(helpDescripton, help.Description),
+			Sender:  c.User,
+		})
 	}
-	b.SendMessage(c.Channel, fmt.Sprintf(helpUsage, CmdPrefix, c.Command, help.ExampleArgs), c.User)
+	b.SendMessage(OutgoingMessage{
+		Target:  c.Channel,
+		Message: fmt.Sprintf(helpUsage, CmdPrefix, c.Command, help.ExampleArgs),
+		Sender:  c.User,
+	})
 }
 
 func (b *Bot) showAvailabeCommands(channel string, sender *User) {
@@ -44,6 +52,14 @@ func (b *Bot) showAvailabeCommands(channel string, sender *User) {
 	for k := range commands {
 		cmds = append(cmds, k)
 	}
-	b.SendMessage(channel, fmt.Sprintf(helpAboutCommand, CmdPrefix), sender)
-	b.SendMessage(channel, fmt.Sprintf(availableCommands, strings.Join(cmds, ", ")), sender)
+	b.SendMessage(OutgoingMessage{
+		Target:  channel,
+		Message: fmt.Sprintf(helpAboutCommand, CmdPrefix),
+		Sender:  sender,
+	})
+	b.SendMessage(OutgoingMessage{
+		Target:  channel,
+		Message: fmt.Sprintf(availableCommands, strings.Join(cmds, ", ")),
+		Sender:  sender,
+	})
 }


### PR DESCRIPTION
This isn't necessary everywhere, but for standardization, I thought
it would be good to really deprecate SendMessageV1.

The place this IS needed is in PeriodicCommands v2 and PassiveCommands
V2. In both those places, objects come back from the caller with ProtoParams
that should be forwarded through to the message sending.