### PR TITLE
Slack: Add methods to directly add or remove reactions

### DIFF
--- a/slack/slack.go
+++ b/slack/slack.go
@@ -56,6 +56,26 @@ func responseHandlerV2(om bot.OutgoingMessage) {
 	}
 }
 
+// AddReactionToMessage allows you to add a reaction, to a message.
+func AddReactionToMessage(msgid, channel string, reaction string) error {
+	toReact := slack.ItemRef{
+		Timestamp: msgid,
+		Channel:   channel,
+	}
+
+	return api.AddReaction(reaction, toReact)
+}
+
+// RemoveReactionFromMessage allows you to remove a reaction, from a message.
+func RemoveReactionFromMessage(msgid, channel string, reaction string) error {
+	reactionRef := slack.ItemRef{
+		Timestamp: msgid,
+		Channel:   channel,
+	}
+
+	return api.RemoveReaction(reaction, reactionRef)
+}
+
 // FindUserBySlackID converts a slack.User into a bot.User struct
 func FindUserBySlackID(userID string) *bot.User {
 	slackUser, err := api.GetUserInfo(userID)


### PR DESCRIPTION
These methods are simple helper methods to expose Slack emoji
reactions to bot commands. Any command that wants to call these
methods obviously is responsible for ensuring that their command
is only used in Slack use cases.

My favorite use case for this is to have the bot auto react to usages
of @here with :please-no-at-here:.

Future Plans: Build a full Reaction Router pattern so that the bots can
register commands to run when a message is tagged with a reaction.
For example:
https://reacji-channeler.builtbyslack.com/