### PR TITLE
Hangouts API no longer sends verification tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Condensed, the steps you will need to take are as follows:
   * Choose "Pub/Sub Editor" role for the credential
 * Enable Pub/Sub API in cloud console
 * Create new topic in the Pub/Sub (say "google-chat")
-  * This is Config.TopicName
+  * Use the value of "Topic Name" (**not** "Topic ID") for Config.TopicName (e.g. /project/<proj_name>/topics/<topic_name>)
 * Modify permissions on created topic so that
   "chat-api-push@system.gserviceaccount.com" has Pub/Sub Publisher permissions
 * Enable hangouts chat api in Cloud Console

--- a/README.md
+++ b/README.md
@@ -192,7 +192,6 @@ Condensed, the steps you will need to take are as follows:
 * Go to hangouts chat API config in the Cloud Console and fill in info
   * Connection settings - use Pub/Sub and fill in topic string you created
     above
-  * Verification token is your Config.Token
 
 Config.SubscriptionName should be unique for each environment or you'll not
 process messages correctly. If you encounter issues make sure your credentials
@@ -220,7 +219,6 @@ func main() {
 		TopicName:        os.Getenv("HANGOUTS_TOPIC"),
 		SubscriptionName: os.Getenv("HANGOUTS_SUB"),
 		WelcomeMessage:   os.Getenv("HANGOUTS_WELCOME"),
-		Token:            os.Getenv("HANGOUTS_TOKEN")})
 }
 
 ```

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/badnetmask/bot
+module github.com/go-chat-bot/bot
 
 require (
 	cloud.google.com/go v0.38.0

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/go-chat-bot/bot
+module github.com/badnetmask/bot
 
 require (
 	cloud.google.com/go v0.38.0

--- a/google-chat/google-chat.go
+++ b/google-chat/google-chat.go
@@ -31,7 +31,6 @@ type Config struct {
 	PubSubProject    string
 	TopicName        string
 	SubscriptionName string
-	Token            string
 	WelcomeMessage   string
 }
 
@@ -119,11 +118,6 @@ func Run(config *Config) {
 			err = json.Unmarshal(m.Data, &msg)
 			if err != nil {
 				log.Printf("Failed message unmarshal(%v): %s\n", err, m.Data)
-				m.Ack()
-				return
-			}
-			if msg.Token != config.Token {
-				log.Printf("Failed to verify token: %s", msg.Token)
 				m.Ack()
 				return
 			}


### PR DESCRIPTION
I can't find a document or blog post to corroborate my findings, but it seems like Hangouts API no longer sends verification tokens along with messages. This is probably because receiving messages via Pub/Sub platform, using a service account, would be considered sufficient authentication.

Granted, this is a brand new deployment, so I am wide open to be proven wrong. I never had a Hangouts bot before, so I don't know what happens to old deployments. All I know is that if you create a new Pub/Sub, the Hangouts API does not expose the verification tokens. I have confirmed that with a friend's account.