### PR TITLE
Parser: Use Fields to account for all unicode white spaces

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"regexp"
 	"strings"
+	"unicode"
 
 	"github.com/mattn/go-shellwords"
 	unidecode "github.com/mozillazg/go-unidecode"
@@ -33,8 +34,18 @@ func parse(m *Message, channel *ChannelData, user *User) (*Cmd, error) {
 		return nil, nil
 	}
 
+	// split command from args by unicode space
+	firstOccurrence := true
+	f := func(c rune) bool {
+		isFirstSpace := unicode.IsSpace(c) && firstOccurrence
+		if isFirstSpace {
+			firstOccurrence = false
+		}
+		return isFirstSpace
+	}
+
 	// get the command
-	pieces := strings.SplitN(c.Message, " ", 2)
+	pieces := strings.FieldsFunc(c.Message, f)
 	c.Command = strings.ToLower(unidecode.Unidecode(pieces[0]))
 
 	if len(pieces) > 1 {

--- a/parser.go
+++ b/parser.go
@@ -35,7 +35,7 @@ func parse(m *Message, channel *ChannelData, user *User) (*Cmd, error) {
 	}
 
 	firstOccurrence := true
-	f := func(c rune) bool {
+	firstUnicodeSpace := func(c rune) bool {
 		isFirstSpace := unicode.IsSpace(c) && firstOccurrence
 		if isFirstSpace {
 			firstOccurrence = false
@@ -44,7 +44,7 @@ func parse(m *Message, channel *ChannelData, user *User) (*Cmd, error) {
 	}
 
 	// get the command
-	pieces := strings.FieldsFunc(c.Message, f)
+	pieces := strings.FieldsFunc(c.Message, firstUnicodeSpace)
 	c.Command = strings.ToLower(unidecode.Unidecode(pieces[0]))
 
 	if len(pieces) > 1 {

--- a/parser.go
+++ b/parser.go
@@ -34,7 +34,6 @@ func parse(m *Message, channel *ChannelData, user *User) (*Cmd, error) {
 		return nil, nil
 	}
 
-	// split command from args by unicode space
 	firstOccurrence := true
 	f := func(c rune) bool {
 		isFirstSpace := unicode.IsSpace(c) && firstOccurrence


### PR DESCRIPTION
strings.SplitN was only matching U+0020 for splitting command and args
Use strings.Fields which checks unicode.IsSpace to account for all unicode white spaces

reference: https://golang.org/pkg/strings/#Fields