### PR TITLE
Replace method GetChannel() due to deprecation

### DIFF
--- a/slack/slack.go
+++ b/slack/slack.go
@@ -139,7 +139,8 @@ func readBotInfo(api *slack.Client) {
 }
 
 func readChannelData(api *slack.Client) {
-	channels, err := api.GetChannels(true)
+	params := slack.GetConversationsParameters{}
+	channels, _, err := api.GetConversations(&params)
 	if err != nil {
 		fmt.Printf("Error getting Channels: %s\n", err)
 		return


### PR DESCRIPTION
Fixed code finally calls [channels.list](https://api.slack.com/methods/channels.list) which is deprecated. Newly created apps after June 10th, 2020 can not work with it.