### PR TITLE
WIP: Fix Slack connection + add some improvements

### DIFF
--- a/google-chat/google-chat.go
+++ b/google-chat/google-chat.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
 
@@ -34,8 +35,16 @@ type Config struct {
 	WelcomeMessage   string
 }
 
+// The Google Chat bot can only talk to "spaces/"
+var gchat_spaces_regexp = regexp.MustCompile("^spaces\\/")
+
 func responseHandler(target string, message string, sender *bot.User) {
 	var space, thread string
+
+	if !(gchat_spaces_regexp.MatchString(target)) {
+		// log.Printf("Google Chat message target does not appear to be a proper space.")
+		return
+	}
 
 	// this define thread in the reply if we can so we don't alwayus start new
 	targets := strings.Split(target, ":")

--- a/google-chat/google-chat.go
+++ b/google-chat/google-chat.go
@@ -36,12 +36,12 @@ type Config struct {
 }
 
 // The Google Chat bot can only talk to "spaces/"
-var gchat_spaces_regexp = regexp.MustCompile("^spaces\\/")
+var gchatSpacesRegexp = regexp.MustCompile("^spaces\\/")
 
 func responseHandler(target string, message string, sender *bot.User) {
 	var space, thread string
 
-	if !(gchat_spaces_regexp.MatchString(target)) {
+	if !(gchatSpacesRegexp.MatchString(target)) {
 		// log.Printf("Google Chat message target does not appear to be a proper space.")
 		return
 	}

--- a/slack/slack.go
+++ b/slack/slack.go
@@ -35,14 +35,14 @@ const protocol = "slack"
 
 // Slack channel names have very specific prefixes:
 // # = channel name, C = channel ID, G = group message, D = direct message
-var slack_channel_regexp = regexp.MustCompile("^[#CGD]")
+var slackChannelRegexp = regexp.MustCompile("^[#CGD]")
 
 func defaultMessageFilter(message string, _ *bot.User) (string, slack.PostMessageParameters) {
 	return message, params
 }
 
 func responseHandler(target string, message string, sender *bot.User) {
-	if !(slack_channel_regexp.MatchString(target)) {
+	if !(slackChannelRegexp.MatchString(target)) {
 		// log.Printf("Slack message target does not appear to be a Slack channel.")
 		return
 	}
@@ -67,7 +67,7 @@ func responseHandler(target string, message string, sender *bot.User) {
 }
 
 func responseHandlerV2(om bot.OutgoingMessage) {
-	if !(slack_channel_regexp.MatchString(om.Target)) {
+	if !(slackChannelRegexp.MatchString(om.Target)) {
 		// log.Printf("Slack messageV2 target does not appear to be a Slack channel.")
 		return
 	}


### PR DESCRIPTION
This PR fixes some problems, and adds some improvements.

This is still a work in progress because I'm still testing (live) and tweaking the code. There is a TODO list at the end as well. However I would like to pre-submit this PR so that the maintainers can take a look and start their review, while I'm still in "developer mode".

- Slack moved away from RTM API, but moving into the Events API would require some heavy re-write, so I added a small patch to make it work for the time being.
- I've been a long time user of the Google Chat plugin, and I liked the fact that I could look at the logs and see how people interact with the bot, so I added that feature to the Slack plugin as well (`SLACK_VERBOSE`).
- Since I'm using the same bot binary to connect to both Slack and Google Chat at the same time, I found out that the [Jira plugin](https://github.com/go-chat-bot/plugins/tree/master/jira) was breaking the bot because it was trying to send the same message to both protocols at the same time. For that reason, I added a check on the outgoing messages of both Slack and Google Chat plugins to make sure the messages only go to them if the destination has the appropriate/expected format. There is *probably* a better way to do that, but this is the only way I could find without being too invasive.

Please, let me know your thoughts.

TODO, before this PR can be merged:

- Document how to create a "classic" Slack bot that uses the RTM API.
- Document how to use the VERBOSE and DEBUG options.
- Document the weird Markdown workaround.